### PR TITLE
Add support for email attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Filters emails to only keep those that are received by the provided address
 openNextUnreadEmail()
 ```
 Pops the most recent unread email and assigns it as the email to conduct tests on
+```
+openNextAttachmentInOpenedEmail()
+```
+Pops the next attachment and assigns it as the attachment to conduct tests on
 
 ### Example Test
 Here is a simple scenario where we test the content of an email.  For a detailed list of all available test methods, please refer to the [Codeception Email Testing Framework][CodeceptionEmailTestingFramework].
@@ -82,5 +86,17 @@ $I->seeInOpenedEmailSubject('Your Password Reset Link');
 $I->seeInOpenedEmailTextBody('Follow this link to reset your password');
 $I->seeInOpenedEmailHtmlBody('<a href="https://www.example.org/">Follow this link to reset your password</a>');
 $I->seeInOpenedEmailRecipients('testuser@example.com');
+
+// Validate if email has attachments
+$I->haveAttachmentsInOpenedEmail();
+
+// Open next attachment
+$I->openNextAttachmentInOpenedEmail();
+
+// Validate metadata of the attachment
+$I->seeInFilenameOfOpenedAttachment();
+$I->grabFilenameFromOpenedAttachment();
+$I->grabContentTypeFromOpenedAttachment();
+$I->grabSizeFromOpenedAttachment();
 ```
 

--- a/src/Mailpit.php
+++ b/src/Mailpit.php
@@ -52,6 +52,11 @@ class Mailpit extends Module
      */
     protected mixed $openedEmail;
 
+    /**
+     * Contains the currently open attachment on the currently opened email.
+     */
+    protected mixed $openedAttachment;
+
     public function _initialize(): void
     {
         $url = trim($this->config['url'], '/') . ':' . $this->config['port'];
@@ -202,6 +207,16 @@ class Mailpit extends Module
     }
 
     /**
+     * Open next attachment in opened email.
+     *
+     * Pops the next attachment and assigns it as the attachment to conduct tests on
+     */
+    public function openNextAttachmentInOpenedEmail(): void
+    {
+        $this->openedAttachment = $this->getNextAttachmentInOpenedEmail();
+    }
+
+    /**
      * Load headers, if not done yet and return the requested header
      *
      * @return null|array<string>
@@ -265,6 +280,15 @@ class Mailpit extends Module
         }
 
         return $this->openedEmail;
+    }
+
+    protected function getOpenedAttachment(bool $fetchNextAttachment = false): mixed
+    {
+        if ($fetchNextAttachment || $this->openedAttachment === null) {
+            $this->openNextAttachmentInOpenedEmail();
+        }
+
+        return $this->openedAttachment;
     }
 
     /**
@@ -483,6 +507,18 @@ class Mailpit extends Module
     protected function getUnreadInbox(): array
     {
         return $this->unreadInbox;
+    }
+
+    protected function getNextAttachmentInOpenedEmail(): mixed
+    {
+        if ($this->openedEmail === null) {
+            $this->fail('No email is opened');
+        }
+        if ($this->openedEmail->Attachments === []) {
+            $this->fail('No attachments in opened email');
+        }
+
+        return array_shift($this->openedEmail->Attachments);
     }
 
     /**

--- a/src/TestsEmails.php
+++ b/src/TestsEmails.php
@@ -4,7 +4,6 @@ namespace Codeception\Module;
 
 // todo:
 // text & html content
-// attachments
 
 trait TestsEmails
 {
@@ -578,6 +577,122 @@ trait TestsEmails
         $email = $this->getOpenedEmail();
         return $this->getHeader($email, $header);
     }
-}
 
-;
+    /**
+     * Assert opened email does not have attachments.
+     */
+    public function dontHaveAttachmentsInOpenedEmail(): void
+    {
+        $email = $this->getOpenedEmail();
+        $this->assertSame([], $email->Attachments ?? []);
+    }
+
+    /**
+     * Assert opened email has attachments.
+     */
+    public function haveAttachmentsInOpenedEmail(): void
+    {
+        $email = $this->getOpenedEmail();
+        $this->assertNotEmpty($email->Attachments ?? []);
+    }
+
+    /**
+     * Assert number of attachments in opened email matches expected size.
+     */
+    public function haveNumberOfAttachmentsInOpenedEmail(int $expected): void
+    {
+        $email = $this->getOpenedEmail();
+        $this->assertCount($expected, $email->Attachments ?? []);
+    }
+
+    /**
+     * Assert given JSON-decoded email does not have attachments.
+     */
+    public function dontHaveAttachmentsInEmail(mixed $email): void
+    {
+        $this->assertSame([], $email->Attachments ?? []);
+    }
+
+    /**
+     * Assert given JSON-decoded email has attachments.
+     */
+    public function haveAttachmentsInEmail(mixed $email): void
+    {
+        $this->assertNotEmpty($email->Attachments ?? []);
+    }
+
+    /**
+     * Assert number of attachments in given JSON-decoded email matches expected size.
+     */
+    public function haveNumberOfAttachmentsInEmail(mixed $email, int $expected): void
+    {
+        $this->assertCount($expected, $email->Attachments ?? []);
+    }
+
+    /**
+     * Assert filename of currently opened attachment in opened email contains $expected.
+     */
+    public function seeInFilenameOfOpenedAttachment(string $expected): void
+    {
+        $this->assertStringContainsString($expected, $this->grabFilenameFromOpenedAttachment());
+    }
+
+    /**
+     * Assert filename of given JSON-decoded attachment contains $expected.
+     */
+    public function seeInFilenameOfAttachment(mixed $attachment, string $expected): void
+    {
+        $this->assertStringContainsString($expected, $this->grabFilenameFromAttachment($attachment));
+    }
+
+    /**
+     * Return filename of currently opened attachment in opened email.
+     */
+    public function grabFilenameFromOpenedAttachment(): string
+    {
+        $attachment = $this->getOpenedAttachment();
+        return $attachment->FileName;
+    }
+
+    /**
+     * Return content-type of currently opened attachment in opened email.
+     */
+    public function grabContentTypeFromOpenedAttachment(): string
+    {
+        $attachment = $this->getOpenedAttachment();
+        return $attachment->ContentType;
+    }
+
+    /**
+     * Return size of currently opened attachment in opened email.
+     */
+    public function grabSizeFromOpenedAttachment(): int
+    {
+        $attachment = $this->getOpenedAttachment();
+        return $attachment->Size;
+    }
+
+    /**
+     * Return filename of given JSON-decoded attachment.
+     */
+    public function grabFilenameFromAttachment(mixed $attachment): string
+    {
+        return $attachment->FileName;
+    }
+
+    /**
+     * Return content-type of given JSON-decoded attachment.
+     */
+    public function grabContentTypeFromAttachment(mixed $attachment): string
+    {
+        return $attachment->ContentType;
+    }
+
+    /**
+     * Return size of given JSON-decoded attachment.
+     */
+    public function grabSizeFromAttachment(mixed $attachment): int
+    {
+        return $attachment->Size;
+    }
+}


### PR DESCRIPTION
This PR adds support for email attachments. The following methods are added:

- `openNextAttachmentInOpenedEmail()`
- `dontHaveAttachmentsInOpenedEmail()`
- `haveAttachmentsInOpenedEmail()`
- `haveNumberOfAttachmentsInOpenedEmail()`
- `dontHaveAttachmentsInEmail()`
- `haveAttachmentsInEmail()`
- `haveNumberOfAttachmentsInEmail()`
- `seeInFilenameOfOpenedAttachment()`
- `seeInFilenameOfAttachment()`
- `grabFilenameFromOpenedAttachment()`
- `grabContentTypeFromOpenedAttachment()`
- `grabSizeFromOpenedAttachment()`
- `grabFilenameFromAttachment()`
- `grabContentTypeFromAttachment()`
- `grabSizeFromAttachment()`